### PR TITLE
cookiecutter v2.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set version = "1.7.3" %}
+{% set name = "cookiecutter" %}
+{% set version = "2.5.0" %}
 
 package:
-  name: cookiecutter
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cookiecutter/cookiecutter-{{ version }}.tar.gz
-  sha256: 6b9a4d72882e243be077a7397d0f1f76fe66cf3df91f3115dbb5330e214fa457
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e61e9034748e3f41b8bd2c11f00d030784b48711c4d5c42363c50989a65331ec
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - cookiecutter = cookiecutter.cli:main
 
@@ -23,47 +23,56 @@ requirements:
     - wheel
   run:
     - python
+    - arrow
     - binaryornot >=0.4.4
-    - click >=7.0
+    - click >=7.0,<9.0.0
     - jinja2 >=2.7,<4.0.0
-    - jinja2-time >=0.2.0
-    - poyo >=0.5.0
     - python-slugify >=4.0.0
+    - pyyaml >=5.3.1
     - requests >=2.23.0
-    - six >=1.10
+    - rich
 
 test:
+  imports:
+    - cookiecutter
+    - cookiecutter.main
+    - cookiecutter.environment
+    - cookiecutter.exceptions
   requires:
     - freezegun
     - git
-    # Omit to avoid falling back to Python 2.7
-    #- mercurial  # [not (win and py3k)]
+    - m2-grep  # [win]
+    # omit mercurial, because it's not available and optional
+    # - mercurial  # [not (win and py3k)]
     - pip
     - pytest
-    - pytest-cov
     - pytest-mock
-    - python 3.*
+    - python
   source_files:
     - tests
   commands:
-    - python -m pip check
+    - pip check
     - cookiecutter --version
+    - cookiecutter --version | grep -iE "Cookiecutter {{ version.replace(".", "\\.") }}"
+    - pip list
+    - pip list | grep -iE "cookiecutter\s+{{ version.replace(".", "\\.") }}"
     - cookiecutter --help
-    # Skip 'make_sure_path_exists' because it does not fail when running the
-    # `conda build` as root (e.g., inside our build containers)
-    - py.test --cov=cookiecutter -v -k 'not make_sure_path_exists'
+    - pytest tests -vv
 
 about:
   home: https://github.com/cookiecutter/cookiecutter
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license: BSD-3-Clause
   dev_url: https://github.com/cookiecutter/cookiecutter
   doc_url: https://cookiecutter.readthedocs.io
-  doc_source_url: https://github.com/cookiecutter/cookiecutter/tree/master/docs
   summary: >
     A command-line utility that creates projects from cookiecutters (project templates), e.g. creating a Python package project from a Python package project template.
-
+  description: |
+    Cookiecutter takes a template provided as a directory structure with template-files. Templates can be located in the filesystem, as a ZIP-file or on a VCS-Server (Git/Hg) like GitHub.
+    It reads a settings file and prompts the user interactively whether or not to change the settings.
+    Then it takes both and generates an output directory structure from it.
+    Additionally the template can provide code (Python or shell-script) to be executed before and after generation (pre-gen- and post-gen-hooks).
 extra:
   recipe-maintainers:
     - bollwyvl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,9 +52,7 @@ test:
     - tests
   commands:
     - pip check
-    - cookiecutter --version
     - cookiecutter --version | grep -iE "Cookiecutter {{ version.replace(".", "\\.") }}"
-    - pip list
     - pip list | grep -iE "cookiecutter\s+{{ version.replace(".", "\\.") }}"
     - cookiecutter --help
     - pytest tests -vv


### PR DESCRIPTION
[PKG-3351] cookiecutter 2.5.0

dev url: https://github.com/cookiecutter/cookiecutter/tree/2.5.0
conda-forge: https://github.com/conda-forge/cookiecutter-feedstock/blob/main/recipe/meta.yaml
dependencies: https://github.com/cookiecutter/cookiecutter/blob/2.5.0/setup.py
pypi: https://pypi.org/project/cookiecutter/

Destination channel: **defaults**

**Changes**
- version 2.5.0 (latest)

**Dependency for**
- [kedro v0.18.14 ❄️](https://anaconda.atlassian.net/browse/PKG-3345)

[PKG-3351]: https://anaconda.atlassian.net/browse/PKG-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ